### PR TITLE
chore: use setup-python github actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,12 +15,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Dependencies 🛠
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install dirmaker
+      - name: Run dirmaker
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8" # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: "x64" # optional x64 or x86. Defaults to x64 if not specified
+      - run: |
+          pip install dirmaker
           mkdir -p site/directory
-          dirmaker --build --putput=site/directory
+          dirmaker --build --output=site/directory
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1


### PR DESCRIPTION
- Uses [setup-python](https://github.com/actions/setup-python) so we can use a specific Python Version and don't have to install any Python deps.
- Fixed a typo in `dirmaker` command.

The actions will still fail (jinj2 installation needs to be done), that needs to be fixed in https://github.com/knadh/dirmaker/ 